### PR TITLE
Add debug feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is the default configuration and an explanation of available options:
 
 ```yaml
 enabled: true
+debug: false
 route: /micropub
 advertise_method: header
 token_endpoint:
@@ -49,6 +50,7 @@ destination:
 Option | Description
 ---|---
 `enabled` | Enable or disable the plugin
+`debug`| Save every request into a yaml file. Files are save in the `user/data/micropub` folder.
 `route` | The route to the endpoint
 `advertise_method` | The method used to advertise the endpoint. This can be in the HTML `<head>` header or as a `<link>` inside the page `<body>`.
 `token_endpoint` | Your authorization token endpoint. This should be the same as advertised on your home page.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -25,6 +25,17 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
+    debug:
+      type: toggle
+      label: PLUGIN_MICROPUB.DEBUG
+      help: PLUGIN_MICROPUB.DEBUG_HELP
+      highlight: 1
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
     route:
       type: text
       label: PLUGIN_MICROPUB.ROUTE

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,5 +1,7 @@
 en:
   PLUGIN_MICROPUB:
+    DEBUG: Debug
+    DEBUG_HELP: Save every request in a yaml file for debugging
     ROUTE: Route
     ROUTE_HELP: The route to the Micropub Endpoint
     ADVERTISE_METHOD: Advertise Method
@@ -34,6 +36,8 @@ en:
 
 nl:
   PLUGIN_MICROPUB:
+    DEBUG: Debug
+    DEBUG_HELP: Bewaar ieder verzoek in een yaml-bestand voor debuggen
     ROUTE: Route
     ROUTE_HELP: De route naar het Micropub Endpoint
     ADVERTISE_METHOD: Methode van aanbieden

--- a/micropub.php
+++ b/micropub.php
@@ -120,7 +120,7 @@ class MicropubPlugin extends Plugin
             $dumpfile .= Yaml::dump($_SERVER);
             $dumpfile .= Yaml::dump($_POST);
             $dumpfile .= Yaml::dump($_GET);
-            $dumpfolder = DATA_DIR . '/micropub;
+            $dumpfolder = DATA_DIR . '/micropub';
             if (!file_exists($dumpfolder)) {
                 mkdir($dumpfolder};
             }

--- a/micropub.php
+++ b/micropub.php
@@ -122,7 +122,7 @@ class MicropubPlugin extends Plugin
             $dumpfile .= Yaml::dump($_GET);
             $dumpfolder = DATA_DIR . '/micropub';
             if (!file_exists($dumpfolder)) {
-                mkdir($dumpfolder};
+                mkdir($dumpfolder);
             }
             $dumpfilename = $dumpfolder . DS . time() . ".yaml';
             file_put_contents($dumpfilename, $dumpfile);

--- a/micropub.php
+++ b/micropub.php
@@ -121,7 +121,7 @@ class MicropubPlugin extends Plugin
             $dumpfile .= Yaml::dump($_POST);
             $dumpfile .= Yaml::dump($_GET);
             $dumpfilename = DATA_DIR . '/micropub/' . date('c');
-            file_put_contents($file, $dumpfile);
+            file_put_contents($dumpfilename, $dumpfile);
         }
         if (!isset($_HEADERS['Authorization'])) {
             $this->throw_401('Missing "Authorization" header.');

--- a/micropub.php
+++ b/micropub.php
@@ -116,10 +116,10 @@ class MicropubPlugin extends Plugin
         }
         if ($this->debug) {
             $dumpfile = '';
-            $dumpfile .= Yaml::parse($_HEADERS);
-            $dumpfile .= Yaml::parse($_SERVER);
-            $dumpfile .= Yaml::parse($_POST);
-            $dumpfile .= Yaml::parse($_GET);
+            $dumpfile .= Yaml::dump($_HEADERS);
+            $dumpfile .= Yaml::dump($_SERVER);
+            $dumpfile .= Yaml::dump($_POST);
+            $dumpfile .= Yaml::dump($_GET);
             $dumpfilename = DATA_DIR . '/micropub/' . date('c');
             file_put_contents($file, $dumpfile);
         }

--- a/micropub.php
+++ b/micropub.php
@@ -26,6 +26,7 @@ use Grav\Common\Config\Config;
 use Grav\Common\Page\Page;
 use Grav\Common\Page\Pages;
 use RocketTheme\Toolbox\Event\Event;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Class MicropubPlugin

--- a/micropub.php
+++ b/micropub.php
@@ -120,7 +120,11 @@ class MicropubPlugin extends Plugin
             $dumpfile .= Yaml::dump($_SERVER);
             $dumpfile .= Yaml::dump($_POST);
             $dumpfile .= Yaml::dump($_GET);
-            $dumpfilename = DATA_DIR . '/micropub/' . time() . '.yaml';
+            $dumpfolder = DATA_DIR . '/micropub;
+            if (!file_exists($dumpfolder)) {
+                mkdir($dumpfolder};
+            }
+            $dumpfilename = $dumpfolder . DS . time() . ".yaml';
             file_put_contents($dumpfilename, $dumpfile);
         }
         if (!isset($_HEADERS['Authorization'])) {

--- a/micropub.php
+++ b/micropub.php
@@ -120,7 +120,7 @@ class MicropubPlugin extends Plugin
             $dumpfile .= Yaml::dump($_SERVER);
             $dumpfile .= Yaml::dump($_POST);
             $dumpfile .= Yaml::dump($_GET);
-            $dumpfilename = DATA_DIR . '/micropub/' . date('c');
+            $dumpfilename = DATA_DIR . '/micropub/' . time();
             file_put_contents($dumpfilename, $dumpfile);
         }
         if (!isset($_HEADERS['Authorization'])) {

--- a/micropub.php
+++ b/micropub.php
@@ -115,11 +115,12 @@ class MicropubPlugin extends Plugin
             $_HEADERS[$name] = $value;
         }
         if ($this->debug) {
-            $dumpfile = '';
-            $dumpfile .= Yaml::dump($_HEADERS);
-            $dumpfile .= Yaml::dump($_SERVER);
-            $dumpfile .= Yaml::dump($_POST);
-            $dumpfile .= Yaml::dump($_GET);
+            $dump = array();
+            $dump['HEADERS'] = $_HEADERS;
+            $dump['SERVER'] = $_SERVER;
+            $dump['POST'] = $_POST;
+            $dump['GET'] = $_GET;
+            $dumpfile = Yaml::dump($dump);
             $dumpfolder = DATA_DIR . '/micropub';
             if (!file_exists($dumpfolder)) {
                 mkdir($dumpfolder);

--- a/micropub.php
+++ b/micropub.php
@@ -116,10 +116,10 @@ class MicropubPlugin extends Plugin
         }
         if ($this->debug) {
             $dump = array();
-            $dump['HEADERS'] = $_HEADERS;
-            $dump['SERVER'] = $_SERVER;
-            $dump['POST'] = $_POST;
-            $dump['GET'] = $_GET;
+            $dump['HEADERS'] = ksort($_HEADERS);
+            $dump['SERVER'] = ksort($_SERVER);
+            $dump['POST'] = ksort($_POST);
+            $dump['GET'] = ksort($_GET);
             $dumpfile = Yaml::dump($dump);
             $dumpfolder = DATA_DIR . '/micropub';
             if (!file_exists($dumpfolder)) {

--- a/micropub.php
+++ b/micropub.php
@@ -33,6 +33,12 @@ use RocketTheme\Toolbox\Event\Event;
  */
 class MicropubPlugin extends Plugin
 {
+
+    /**
+     * @var boolean
+     */
+    protected $debug;
+
     /**
      * @return array
      *
@@ -59,6 +65,8 @@ class MicropubPlugin extends Plugin
         if ($this->isAdmin()) {
             return;
         }
+
+        $this->debug = true; // TODO: get from config
 
         $config = $this->grav['config'];
         $enabled = array();
@@ -104,6 +112,15 @@ class MicropubPlugin extends Plugin
         $_HEADERS = array();
         foreach(getallheaders() as $name => $value) {
             $_HEADERS[$name] = $value;
+        }
+        if ($this->debug) {
+            $dumpfile = '';
+            $dumpfile .= Yaml::parse($_HEADERS);
+            $dumpfile .= Yaml::parse($_SERVER);
+            $dumpfile .= Yaml::parse($_POST);
+            $dumpfile .= Yaml::parse($_GET);
+            $dumpfilename = DATA_DIR . '/micropub/' . date('c');
+            file_put_contents($file, $dumpfile);
         }
         if (!isset($_HEADERS['Authorization'])) {
             $this->throw_401('Missing "Authorization" header.');

--- a/micropub.php
+++ b/micropub.php
@@ -116,10 +116,10 @@ class MicropubPlugin extends Plugin
         }
         if ($this->debug) {
             $dump = array();
-            $dump['HEADERS'] = ksort($_HEADERS);
-            $dump['SERVER'] = ksort($_SERVER);
-            $dump['POST'] = ksort($_POST);
-            $dump['GET'] = ksort($_GET);
+            $dump['HEADERS'] = $_HEADERS;
+            $dump['SERVER'] = $_SERVER;
+            $dump['POST'] = $_POST;
+            $dump['GET'] = $_GET;
             $dumpfile = Yaml::dump($dump);
             $dumpfolder = DATA_DIR . '/micropub';
             if (!file_exists($dumpfolder)) {

--- a/micropub.php
+++ b/micropub.php
@@ -67,11 +67,11 @@ class MicropubPlugin extends Plugin
             return;
         }
 
-        $this->debug = true; // TODO: get from config
-
         $config = $this->grav['config'];
-        $enabled = array();
 
+        $this->debug = $config->get('plugins.micropub.debug');
+
+        $enabled = array();
         $enabled = $this->addEnable($enabled, 'onTwigTemplatePaths', ['onTwigTemplatePaths', 0]);
 
         // ROUTE

--- a/micropub.php
+++ b/micropub.php
@@ -120,7 +120,7 @@ class MicropubPlugin extends Plugin
             $dumpfile .= Yaml::dump($_SERVER);
             $dumpfile .= Yaml::dump($_POST);
             $dumpfile .= Yaml::dump($_GET);
-            $dumpfilename = DATA_DIR . '/micropub/' . time();
+            $dumpfilename = DATA_DIR . '/micropub/' . time() . '.yaml';
             file_put_contents($dumpfilename, $dumpfile);
         }
         if (!isset($_HEADERS['Authorization'])) {

--- a/micropub.php
+++ b/micropub.php
@@ -124,7 +124,7 @@ class MicropubPlugin extends Plugin
             if (!file_exists($dumpfolder)) {
                 mkdir($dumpfolder);
             }
-            $dumpfilename = $dumpfolder . DS . time() . ".yaml';
+            $dumpfilename = $dumpfolder . DS . time() . ".yaml";
             file_put_contents($dumpfilename, $dumpfile);
         }
         if (!isset($_HEADERS['Authorization'])) {

--- a/micropub.yaml
+++ b/micropub.yaml
@@ -1,4 +1,5 @@
 enabled: true
+debug: false
 route: /micropub
 advertise_method: header
 parent_route:


### PR DESCRIPTION
Since it is unclear what various clients post, and thus why the endpoint sometimes does not work, I have now added a feature to enable debugging through the plugin configuration.

If enabled, any request will be saved in a separate yaml file in the `user/data/micropub` folder.